### PR TITLE
Update dependencies

### DIFF
--- a/scripts/check-dependencies
+++ b/scripts/check-dependencies
@@ -7,10 +7,10 @@ check() {
   }
 }
 
+check dos2unix
 check go 'Go'
 check http 'HTTPie'
+check jq
 check ruby 'Ruby'
 check rustc 'Rust'
 check zsh
-check jq
-check dos2unix

--- a/scripts/check-dependencies
+++ b/scripts/check-dependencies
@@ -9,7 +9,6 @@ check() {
 
 check go 'Go'
 check http 'HTTPie'
-check node 'node.js'
 check ruby 'Ruby'
 check rustc 'Rust'
 check zsh

--- a/scripts/check-dependencies
+++ b/scripts/check-dependencies
@@ -12,3 +12,5 @@ check http 'HTTPie'
 check ruby 'Ruby'
 check rustc 'Rust'
 check zsh
+check jq
+check dos2unix


### PR DESCRIPTION
- No need for `node` anymore
- `jq` and `dos2unix` are needed now